### PR TITLE
【feature】なぞかけランダム生成機能の実装

### DIFF
--- a/app/controllers/nazokakes_controller.rb
+++ b/app/controllers/nazokakes_controller.rb
@@ -1,0 +1,8 @@
+class NazokakesController < ApplicationController
+  def index
+    @question = Question.random
+    @answer = Answer.random
+    @heart = Heart.random
+  end
+end
+

--- a/app/helpers/nazokakes_helper.rb
+++ b/app/helpers/nazokakes_helper.rb
@@ -1,0 +1,2 @@
+module NazokakesHelper
+end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,3 +1,7 @@
 class Answer < ApplicationRecord
   belongs_to :user
+
+  def self.random
+    order(Arel.sql('RANDOM()')).first
+  end
 end

--- a/app/models/heart.rb
+++ b/app/models/heart.rb
@@ -1,3 +1,7 @@
 class Heart < ApplicationRecord
   belongs_to :user
+
+  def self.random
+    order(Arel.sql('RANDOM()')).first
+  end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,3 +1,7 @@
 class Question < ApplicationRecord
   belongs_to :user
+
+  def self.random
+    order(Arel.sql('RANDOM()')).first
+  end
 end

--- a/app/views/nazokakes/index.html.erb
+++ b/app/views/nazokakes/index.html.erb
@@ -1,0 +1,49 @@
+<div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
+
+  <div class="sm:mx-auto sm:w-full sm:max-w-sm">
+    <h1 class="my-1 text-center text-2xl font-bold leading-9 text-gray-900">ランダムなぞかけ</h1>
+  </div>
+
+  <div class="my-3 card w-full bg-base-100 shadow-xl">
+
+    <div class="m-10 text-center justify-center">
+      <% if @question && @answer && @heart %>
+        <div class="m-3 flex text-center justify-center">
+          <div class="m-3">
+            <strong><%= @question.content %></strong>
+          </div>
+          <div class="m-3 text-gray-400">
+            とかけて
+          </div>
+        </div>
+
+        <div class="m-3 flex text-center justify-center">
+          <div class="m-3">
+            <strong><%= @answer.content %></strong>
+          </div>
+          <div class="m-3 text-gray-400">
+            と解く
+          </div>
+        </div>
+
+        <div class="m-3 flex text-center justify-center">
+          <div class="m-3 text-gray-400">
+            その心は、どちらも
+          </div>
+          <div class="m-3">
+            <strong><%= @heart.content %></strong>
+          </div>
+        </div>
+
+      <% else %>
+        <p>なぞかけの要素が足りません。</p>
+      <% end %>
+
+      <div class="actions">
+        <%= link_to 'ランダム生成', nazokakes_path, class: "m-5 btn btn-primary w-1/4" %>
+      </div>
+    </div>
+
+  </div>
+
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -20,7 +20,7 @@
             <% end %>
 
             <div class="mr-3 my-1">
-              <%= post.content %>
+              <strong><%= post.content %></strong>
             </div>
             <div class="text-gray-400">
               <%= case post.class.name

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -13,7 +13,7 @@
       <%= link_to "ユーザー詳細", user_path(@user) %>
     </div>
     <div class="ml-3 btn btn-outline btn-primary flex-auto w-full justify-center rounded-md">
-      <%= link_to "ユーザー一覧に戻る", users_path %>
+      <%= link_to "ユーザー一覧", users_path %>
     </div>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   resources :users
 
   resources :posts, only: [:new, :create, :index]
-
+  resources :nazokakes, only: [:index]
   resources :questions, only: [:new, :create]
   resources :answers, only: [:new, :create]
   resources :hearts, only: [:new, :create]

--- a/test/controllers/nazokakes_controller_test.rb
+++ b/test/controllers/nazokakes_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class NazokakesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 概要

なぞかけランダム生成機能の実装

### 説明

このプルリクエストでは、以下の機能を実装しました

1. **ランダム選択ロジックの追加**: `Question`, `Answer`, `Heart` モデルにランダムにデータを選択するメソッドを追加しました。
2. **Nazokakesコントローラの追加**: なぞかけを生成する`index`アクションを含む新しいコントローラを作成しました。
3. **ビューの設計**: 生成されたなぞかけを表示するためのビューを作成し、ユーザーが新しいなぞかけを要求できるように「もう一度生成する」ボタンを追加しました。

これにより、ユーザーは保存された`問`, `解`, `心`からランダムに選ばれたものを組み合わせて新しいなぞかけを見ることができます。