### PR TITLE
【feature】Twitter共有機能の追加

### DIFF
--- a/app/controllers/nazokakes_controller.rb
+++ b/app/controllers/nazokakes_controller.rb
@@ -3,6 +3,8 @@ class NazokakesController < ApplicationController
     @question = Question.random
     @answer = Answer.random
     @heart = Heart.random
+
+    tweet_content = "**ランダムなぞかけ**\n\n【#{@question.content}】とかけて\n【#{@answer.content}】と解く\nその心は、どちらも【#{@heart.content}】\n#かかってる #なぞかけ\n\nkakatteru.onrender.com"
+    @encoded_text = URI.encode_www_form_component(tweet_content)
   end
 end
-

--- a/app/controllers/nazokakes_controller.rb
+++ b/app/controllers/nazokakes_controller.rb
@@ -1,4 +1,6 @@
 class NazokakesController < ApplicationController
+  skip_before_action :require_login, only: [:index]
+
   def index
     @question = Question.random
     @answer = Answer.random

--- a/app/views/nazokakes/index.html.erb
+++ b/app/views/nazokakes/index.html.erb
@@ -40,10 +40,19 @@
       <% end %>
 
       <div class="actions">
-        <%= link_to 'ランダム生成', nazokakes_path, class: "m-5 btn btn-primary w-1/4" %>
+        <%= link_to 'ランダム生成', nazokakes_path, class: "m-5 btn btn-primary btn-wide" %>
+      </div>
+
+    <div class="m-3 flex text-center justify-center">
+      <div class="actions">
+        <%= link_to "Twitterで共有する", "https://twitter.com/intent/tweet?text=#{@encoded_text}", target: "_blank", class: "m-2 btn btn-outline btn-info btn-wide" %>
+      </div>
+
+      <div class="actions">
+        <%= link_to '投稿してみる', new_post_path, class: "m-2 btn btn-outline btn-secondary btn-wide" %>
       </div>
     </div>
-
+    </div>
   </div>
 
 </div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -5,9 +5,11 @@
   <div class="flex-none">
     <ul class="menu menu-horizontal px-1">
       <li>
+        <%= link_to "ランダム生成", nazokakes_path %>
+      </li>
+      <li>
         <%= link_to "投稿一覧", posts_path %>
       </li>
-
       <li>
         <%= link_to "新規登録", new_user_path %>
       </li>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,6 +5,9 @@
   <div class="flex-none">
     <ul class="menu menu-horizontal px-1">
       <li>
+        <%= link_to "ランダム生成", nazokakes_path %>
+      </li>
+      <li>
         <%= link_to "新規投稿", new_post_path %>
       </li>
       <li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root "posts#index"
+  root "nazokakes#index"
   resources :users
 
   resources :posts, only: [:new, :create, :index]


### PR DESCRIPTION
### タイトル

Twitter共有機能の追加

### 説明

このプルリクエストでは、なぞかけアプリにTwitterで共有する機能を実装しました。以下の変更が含まれています。

1. **Tweet内容のフォーマット**: なぞかけの「問」「解」「心」をフォーマットし、ハッシュタグと共に投稿内容を整形しました。
2. **エンコーディング**: ツイート内容をURLエンコードし、Twitterの投稿リンクに適切に組み込むことができるようにしました。
3. **ビューの更新**: `nazokakes/index.html.erb`に「Twitterで共有する」ボタンを追加し、エンコードされたテキストを利用してユーザーが直接Twitterに投稿できるようにしました。

これにより、ユーザーは生成されたなぞかけを簡単にTwitterで共有できるようになります。